### PR TITLE
Add support for generating page properties for each path.

### DIFF
--- a/swagger-confluence-cli/src/main/java/net/slkdev/swagger/confluence/cli/SwaggerConfluence.java
+++ b/swagger-confluence-cli/src/main/java/net/slkdev/swagger/confluence/cli/SwaggerConfluence.java
@@ -79,7 +79,10 @@ public class SwaggerConfluence {
         options.addOption("p", "prefix", true, "Prefix to use for article titles to ensure uniqueness");
         options.addOption("t", "title", true, "Base title to use for the root article of the API doc");
         options.addOption("u", "confluence-rest-api-url", true, "URL to the confluence REST API");
-
+        options.addOption("P", "page-properties-macro-id", true, "Add hidden page properties for each route.");
+        options.addOption("I", "page-properties-id", true, "Optional ID used to identify a particular " +
+                          "Page Properties macro on a page. Specify this ID in the Page Properties Report " +
+                          "to include summary information from macros with this ID only.");
         return options;
     }
 
@@ -127,6 +130,8 @@ public class SwaggerConfluence {
         swaggerConfluenceConfig.setSpaceKey(commandLine.getOptionValue("k"));
         swaggerConfluenceConfig.setSwaggerSchema(commandLine.getOptionValue("s"));
         swaggerConfluenceConfig.setTitle(commandLine.getOptionValue("t"));
+        swaggerConfluenceConfig.setMacroId(commandLine.getOptionValue("P"));
+        swaggerConfluenceConfig.setPropertiesId(commandLine.getOptionValue("I"));
 
         return swaggerConfluenceConfig;
     }

--- a/swagger-confluence-core/src/main/java/net/slkdev/swagger/confluence/config/SwaggerConfluenceConfig.java
+++ b/swagger-confluence-core/src/main/java/net/slkdev/swagger/confluence/config/SwaggerConfluenceConfig.java
@@ -31,6 +31,8 @@ public class SwaggerConfluenceConfig {
     private String spaceKey;
     private String swaggerSchema;
     private String title;
+    private String macroId;
+    private String propertiesId;
 
     public SwaggerConfluenceConfig() {
         generateNumericPrefixes = true;
@@ -140,6 +142,22 @@ public class SwaggerConfluenceConfig {
 
     public void setTitle(final String title) {
         this.title = title;
+    }
+
+    public String getMacroId() {
+        return macroId;
+    }
+
+    public void setMacroId(final String macroId) {
+        this.macroId = macroId;
+    }
+
+    public String getPropertiesId() {
+        return propertiesId;
+    }
+
+    public void setPropertiesId(final String propertiesId) {
+        this.propertiesId = propertiesId;
     }
 
 }


### PR DESCRIPTION
In case this is something you find useful.

I wanted it so we can create a page, listing all the paths in a nice table on another page using the page properties report macro.

May look something like this (minimal swagger spec that was imported, at the moment):
![image](https://user-images.githubusercontent.com/72965/32407840-eaa625b0-c18e-11e7-917b-2aa0a7b05a8f.png)
